### PR TITLE
Option to disable host code generation for CUDA targets

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -58,6 +58,7 @@ ppcg_SOURCES = \
 	ppcg_options.h \
 	ppcg.c \
 	ppcg.h \
+	ppcg_main.c \
 	print.c \
 	print.h \
 	util.c \

--- a/ppcg_options.c
+++ b/ppcg_options.c
@@ -107,6 +107,8 @@ ISL_ARG_STR(struct ppcg_options, sizes, 0, "sizes", "sizes", NULL,
 	"Per kernel tile, grid and block sizes")
 ISL_ARG_INT(struct ppcg_options, max_shared_memory, 0,
 	"max-shared-memory", "size", 8192, "maximal amount of shared memory")
+ISL_ARG_BOOL(struct ppcg_options, print_host_code, 0, "print-host-code", 1,
+	"Generate host code (CUDA targets)")
 ISL_ARG_BOOL(struct ppcg_options, openmp, 0, "openmp", 0,
 	"Generate OpenMP macros (only for C target)")
 ISL_ARG_USER_OPT_CHOICE(struct ppcg_options, target, 0, "target", target,

--- a/ppcg_options.h
+++ b/ppcg_options.h
@@ -47,6 +47,9 @@ struct ppcg_options {
 	/* Maximal amount of shared memory. */
 	int max_shared_memory;
 
+	/* Print host code (CUDA target). */
+	int print_host_code;
+
 	/* The target we generate code for. */
 	int target;
 


### PR DESCRIPTION
If ppcg is integrated as a part of a large framework that manages data copying
and kernel launches, generating only kernels is sufficient.  Fail generation if
some host-level control flow is necessary.

Cleaner version with a config option to preserve backwards-compatibility.