### PR TITLE
Default sizes chosen by PPCG are confusing, drop them

### DIFF
--- a/gpu.c
+++ b/gpu.c
@@ -618,17 +618,17 @@ static void read_block_sizes(struct ppcg_kernel *kernel,
 		kernel->n_block = 3;
 	switch (kernel->n_block) {
 	case 1:
-                kernel->block_dim[0] = 1; //512;
-                break;
-        case 2:
-                kernel->block_dim[0] = 1; //32;
-                kernel->block_dim[1] = 1; //16;
-                break;
+		kernel->block_dim[0] = 1; //512;
+		break;
+	case 2:
+		kernel->block_dim[0] = 1; //32;
+		kernel->block_dim[1] = 1; //16;
+		break;
 	default:
-                kernel->block_dim[0] = 1; //32;
-                kernel->block_dim[1] = 1; //4;
-                kernel->block_dim[2] = 1; //4;
-                break;
+		kernel->block_dim[0] = 1; //32;
+		kernel->block_dim[1] = 1; //4;
+		kernel->block_dim[2] = 1; //4;
+		break;
 	}
 
 	size = extract_sizes(sizes, "block", kernel->id);
@@ -647,11 +647,11 @@ static void read_grid_sizes(struct ppcg_kernel *kernel,
 		kernel->n_grid = 2;
 	switch (kernel->n_grid) {
 	case 1:
-                kernel->grid_dim[0] = 1;//32768;
+		kernel->grid_dim[0] = 1;//32768;
 		break;
 	default:
-                kernel->grid_dim[0] = 1; //256;
-                kernel->grid_dim[1] = 1; //256;
+		kernel->grid_dim[0] = 1; //256;
+		kernel->grid_dim[1] = 1; //256;
 		break;
 	}
 

--- a/gpu.c
+++ b/gpu.c
@@ -618,17 +618,17 @@ static void read_block_sizes(struct ppcg_kernel *kernel,
 		kernel->n_block = 3;
 	switch (kernel->n_block) {
 	case 1:
-		kernel->block_dim[0] = 512;
-		break;
-	case 2:
-		kernel->block_dim[0] = 32;
-		kernel->block_dim[1] = 16;
-		break;
+                kernel->block_dim[0] = 1; //512;
+                break;
+        case 2:
+                kernel->block_dim[0] = 1; //32;
+                kernel->block_dim[1] = 1; //16;
+                break;
 	default:
-		kernel->block_dim[0] = 32;
-		kernel->block_dim[1] = 4;
-		kernel->block_dim[2] = 4;
-		break;
+                kernel->block_dim[0] = 1; //32;
+                kernel->block_dim[1] = 1; //4;
+                kernel->block_dim[2] = 1; //4;
+                break;
 	}
 
 	size = extract_sizes(sizes, "block", kernel->id);
@@ -647,11 +647,11 @@ static void read_grid_sizes(struct ppcg_kernel *kernel,
 		kernel->n_grid = 2;
 	switch (kernel->n_grid) {
 	case 1:
-		kernel->grid_dim[0] = 32768;
+                kernel->grid_dim[0] = 1;//32768;
 		break;
 	default:
-		kernel->grid_dim[0] = 256;
-		kernel->grid_dim[1] = 256;
+                kernel->grid_dim[0] = 1; //256;
+                kernel->grid_dim[1] = 1; //256;
 		break;
 	}
 
@@ -4444,7 +4444,7 @@ static __isl_give isl_schedule *compute_schedule(struct gpu_gen *gen)
 		sc = isl_schedule_constraints_set_custom_constraint_callback(sc,
 			gen->add_schedule_constraints,
 			gen->add_schedule_constraints_user);
-	
+
 	if (gen->merge_callback) {
 		sc = isl_schedule_constraints_set_merge_callback(sc,
 			gen->merge_callback, gen->merge_callback_user);

--- a/ppcg_options.c
+++ b/ppcg_options.c
@@ -102,7 +102,8 @@ ISL_ARG_BOOL(struct ppcg_options, non_negative_parameters, 0,
 	"assume all parameters are non-negative)")
 ISL_ARG_BOOL(struct ppcg_options, tile, 0, "tile", 0,
 	"perform tiling (C target)")
-ISL_ARG_INT(struct ppcg_options, tile_size, 'S', "tile-size", "size", 32, NULL)
+//ISL_ARG_INT(struct ppcg_options, tile_size, 'S', "tile-size", "size", 32, NULL)
+ISL_ARG_INT(struct ppcg_options, tile_size, 'S', "tile-size", "size", 1, NULL)
 ISL_ARG_BOOL(struct ppcg_options, isolate_full_tiles, 0, "isolate-full-tiles",
 	0, "isolate full tiles from partial tiles (hybrid tiling)")
 ISL_ARG_STR(struct ppcg_options, sizes, 0, "sizes", "sizes", NULL,


### PR DESCRIPTION
I am invoking the principle of least surprise.
By default if nothing is given, code should be readable and perf should be terrible.