### PR TITLE
cross band tiling

### DIFF
--- a/gpu.c
+++ b/gpu.c
@@ -4507,7 +4507,7 @@ static __isl_give isl_schedule_node *band_set_coincident(
 /* If "node" is a band, then set its properties.
  *
  * In particular, if the band has exactly one member, then mark it permutable.
- * Mark the band member coincident based on the coincidence constraints
+ * Mark the band members coincident based on the coincidence constraints
  * of "sc".
  */
 static __isl_give isl_schedule_node *set_band_properties(

--- a/gpu.c
+++ b/gpu.c
@@ -4401,114 +4401,7 @@ static __isl_give isl_schedule *compute_schedule(struct gpu_gen *gen)
 	return schedule;
 }
 
-/* If the band node "node" has exactly one member then mark it permutable.
- */
-static __isl_give isl_schedule_node *band_set_permutable(
-	__isl_take isl_schedule_node *node,
-	__isl_keep isl_schedule_constraints *sc)
-{
-	if (isl_schedule_node_band_n_member(node) == 1)
-		node = isl_schedule_node_band_set_permutable(node, 1);
-
-	return node;
-}
-
-/* Return the coincidence constraints between pairs of instances
- * that are scheduled together by the ancestors of "node".
- * That is, select those coincidence constraints that relate
- * pairs of instances that have the same value for the prefix schedule.
- * If the schedule depth is zero, then the prefix schedule does not
- * contain any information, so we intersect domain and range
- * of the schedule constraints with the reaching domain elements instead.
- */
-static __isl_give isl_union_map *get_local_coincidence(
-	__isl_keep isl_schedule_node *node,
-	__isl_keep isl_schedule_constraints *sc)
-{
-	isl_union_map *coincidence;
-	isl_multi_union_pw_aff *prefix;
-	isl_union_pw_multi_aff *contraction;
-
-	coincidence = isl_schedule_constraints_get_coincidence(sc);
-	contraction = isl_schedule_node_get_subtree_contraction(node);
-	if (isl_schedule_node_get_schedule_depth(node) == 0) {
-		isl_union_set *domain;
-
-		domain = isl_schedule_node_get_domain(node);
-		domain = isl_union_set_preimage_union_pw_multi_aff(domain,
-						    contraction);
-		coincidence = isl_union_map_intersect_domain(coincidence,
-						    isl_union_set_copy(domain));
-		coincidence = isl_union_map_intersect_range(coincidence,
-						    domain);
-		return coincidence;
-	}
-
-	prefix = isl_schedule_node_get_prefix_schedule_multi_union_pw_aff(node);
-	prefix = isl_multi_union_pw_aff_pullback_union_pw_multi_aff(prefix,
-								contraction);
-	return isl_union_map_eq_at_multi_union_pw_aff(coincidence, prefix);
-}
-
-/* For each member in the band node "node", determine whether
- * it is coincident with respect to the outer nodes and mark
- * it accordingly.
- *
- * That is, for each coincidence constraint between pairs
- * of instances that are scheduled together by the outer nodes,
- * check that domain and range are assigned the same value
- * by the band member.  This test is performed by checking
- * that imposing the same value for the band member does not
- * remove any elements from the set of coincidence constraints.
- */
-static __isl_give isl_schedule_node *band_set_coincident(
-	__isl_take isl_schedule_node *node,
-	__isl_keep isl_schedule_constraints *sc)
-{
-	isl_union_map *coincidence;
-	isl_union_pw_multi_aff *contraction;
-	isl_multi_union_pw_aff *partial;
-	int i, n;
-
-	coincidence = get_local_coincidence(node, sc);
-
-	partial = isl_schedule_node_band_get_partial_schedule(node);
-	contraction = isl_schedule_node_get_subtree_contraction(node);
-	partial = isl_multi_union_pw_aff_pullback_union_pw_multi_aff(partial,
-								contraction);
-	n = isl_schedule_node_band_n_member(node);
-	for (i = 0; i < n; ++i) {
-		isl_union_map *coincidence_i;
-		isl_union_pw_aff *upa;
-		isl_multi_union_pw_aff *partial_i;
-		int subset;
-
-		upa = isl_multi_union_pw_aff_get_union_pw_aff(partial, i);
-		partial_i = isl_multi_union_pw_aff_from_union_pw_aff(upa);
-		coincidence_i = isl_union_map_copy(coincidence);
-		coincidence_i = isl_union_map_eq_at_multi_union_pw_aff(
-						    coincidence_i, partial_i);
-		subset = isl_union_map_is_subset(coincidence, coincidence_i);
-		isl_union_map_free(coincidence_i);
-
-		if (subset < 0)
-			break;
-		node = isl_schedule_node_band_member_set_coincident(node, i,
-								    subset);
-	}
-	if (i < n)
-		node = isl_schedule_node_free(node);
-	isl_multi_union_pw_aff_free(partial);
-	isl_union_map_free(coincidence);
-
-	return node;
-}
-
 /* If "node" is a band, then set its properties.
- *
- * In particular, if the band has exactly one member, then mark it permutable.
- * Mark the band members coincident based on the coincidence constraints
- * of "sc".
  */
 static __isl_give isl_schedule_node *set_band_properties(
 	__isl_take isl_schedule_node *node, void *user)
@@ -4517,13 +4410,8 @@ static __isl_give isl_schedule_node *set_band_properties(
 
 	if (isl_schedule_node_get_type(node) != isl_schedule_node_band)
 		return node;
-	if (isl_schedule_node_band_n_member(node) == 0)
-		return node;
 
-	node = band_set_permutable(node, sc);
-	node = band_set_coincident(node, sc);
-
-	return node;
+	return ppcg_schedule_node_band_set_properties(node, sc);
 }
 
 /* Return the original schedule with all bands marked permutable and

--- a/schedule.c
+++ b/schedule.c
@@ -215,9 +215,6 @@ static __isl_give isl_schedule_node *band_set_permutable(
  * that are scheduled together by the ancestors of "node".
  * That is, select those coincidence constraints that relate
  * pairs of instances that have the same value for the prefix schedule.
- * If the schedule depth is zero, then the prefix schedule does not
- * contain any information, so we intersect domain and range
- * of the schedule constraints with the reaching domain elements instead.
  */
 static __isl_give isl_union_map *get_local_coincidence(
 	__isl_keep isl_schedule_node *node,
@@ -229,19 +226,6 @@ static __isl_give isl_union_map *get_local_coincidence(
 
 	coincidence = isl_schedule_constraints_get_coincidence(sc);
 	contraction = isl_schedule_node_get_subtree_contraction(node);
-	if (isl_schedule_node_get_schedule_depth(node) == 0) {
-		isl_union_set *domain;
-
-		domain = isl_schedule_node_get_domain(node);
-		domain = isl_union_set_preimage_union_pw_multi_aff(domain,
-						    contraction);
-		coincidence = isl_union_map_intersect_domain(coincidence,
-						    isl_union_set_copy(domain));
-		coincidence = isl_union_map_intersect_range(coincidence,
-						    domain);
-		return coincidence;
-	}
-
 	prefix = isl_schedule_node_get_prefix_schedule_multi_union_pw_aff(node);
 	prefix = isl_multi_union_pw_aff_pullback_union_pw_multi_aff(prefix,
 								contraction);

--- a/schedule.h
+++ b/schedule.h
@@ -28,4 +28,14 @@ __isl_give isl_schedule_node *ppcg_schedule_node_band_set_properties(
 	__isl_take isl_schedule_node *node,
 	__isl_keep isl_schedule_constraints *sc);
 
+isl_bool ppcg_schedule_node_has_cross_tile_shape(
+	__isl_keep isl_schedule_node *node);
+isl_bool ppcg_schedule_node_plain_can_cross_tile(
+	__isl_keep isl_schedule_node *node);
+__isl_give isl_space *ppcg_schedule_node_get_cross_tile_space(
+	__isl_keep isl_schedule_node *node);
+__isl_give isl_schedule_node *ppcg_schedule_node_cross_tile(
+	__isl_take isl_schedule_node *node, __isl_take isl_multi_val *sizes,
+	__isl_keep isl_schedule_constraints *sc);
+
 #endif

--- a/schedule.h
+++ b/schedule.h
@@ -32,6 +32,8 @@ isl_bool ppcg_schedule_node_has_cross_tile_shape(
 	__isl_keep isl_schedule_node *node);
 isl_bool ppcg_schedule_node_plain_can_cross_tile(
 	__isl_keep isl_schedule_node *node);
+isl_bool ppcg_schedule_node_can_cross_tile(__isl_keep isl_schedule_node *node,
+	__isl_keep isl_schedule_constraints *sc);
 __isl_give isl_space *ppcg_schedule_node_get_cross_tile_space(
 	__isl_keep isl_schedule_node *node);
 __isl_give isl_schedule_node *ppcg_schedule_node_cross_tile(

--- a/schedule.h
+++ b/schedule.h
@@ -24,4 +24,8 @@ __isl_give isl_schedule *ppcg_get_schedule(isl_ctx *ctx,
 __isl_give isl_schedule_node *ppcg_set_schedule_node_type(
 	__isl_take isl_schedule_node *node, enum isl_ast_loop_type type);
 
+__isl_give isl_schedule_node *ppcg_schedule_node_band_set_properties(
+	__isl_take isl_schedule_node *node,
+	__isl_keep isl_schedule_constraints *sc);
+
 #endif

--- a/util.c
+++ b/util.c
@@ -1,16 +1,21 @@
 /*
  * Copyright 2012-2013 Ecole Normale Superieure
+ * Copyright 2015      INRIA Rocquencourt
  *
  * Use of this software is governed by the MIT license
  *
  * Written by Sven Verdoolaege,
  * Ecole Normale Superieure, 45 rue d'Ulm, 75230 Paris, France
+ * and Inria Paris - Rocquencourt, Domaine de Voluceau - Rocquencourt,
+ * B.P. 105 - 78153 Le Chesnay, France
  */
 
 #include <isl/space.h>
 #include <isl/val.h>
 #include <isl/aff.h>
 #include <isl/set.h>
+#include <isl/union_set.h>
+#include <isl/union_map.h>
 
 #include "util.h"
 
@@ -102,4 +107,22 @@ __isl_give isl_multi_pw_aff *ppcg_size_from_extent(__isl_take isl_set *set)
 	isl_set_free(set);
 
 	return mpa;
+}
+
+/* Given a binary relation between tagged instances,
+ * construct a function that drops the tags from
+ * the domain and the range instances.
+ */
+__isl_give isl_union_pw_multi_aff *ppcg_extract_untag_from_tagged_relation(
+	__isl_keep isl_union_map *tagged)
+{
+	isl_union_map *universe;
+	isl_union_set *domain, *range;
+
+	universe = isl_union_map_universe(isl_union_map_copy(tagged));
+	domain = isl_union_map_domain(isl_union_map_copy(universe));
+	range = isl_union_map_range(universe);
+	domain = isl_union_set_union(domain, range);
+	universe = isl_union_set_unwrap(domain);
+	return isl_union_map_domain_map_union_pw_multi_aff(universe);
 }

--- a/util.h
+++ b/util.h
@@ -5,6 +5,8 @@
 
 #include <isl/space.h>
 #include <isl/val.h>
+#include <isl/aff_type.h>
+#include <isl/union_map_type.h>
 
 /* Compare the prefix of "s" to "prefix" up to the length of "prefix".
  */
@@ -18,5 +20,8 @@ __isl_give isl_multi_val *ppcg_multi_val_from_int(__isl_take isl_space *space,
 __isl_give isl_multi_val *ppcg_multi_val_from_int_list(
 	__isl_take isl_space *space, int *list);
 __isl_give isl_multi_pw_aff *ppcg_size_from_extent(__isl_take isl_set *set);
+
+__isl_give isl_union_pw_multi_aff *ppcg_extract_untag_from_tagged_relation(
+	__isl_keep isl_union_map *tagged);
 
 #endif


### PR DESCRIPTION
Essentially three functions are provided.

1. check whether cross band tiling can be applied
2. obtain the space for the tile sizes
3. perform cross band tiling

The child nodes are expected to live in the same space for sanity.
This should work in simple cases.
In other cases, the spaces would either to be homogenized prior
to the cross band tiling or cross band tiling would have to be extended in some way.