### PR TITLE
[DO-NOT-MERGE] illustrate call to ppcg_schedule_node_can_cross_tile

### DIFF
--- a/gpu.c
+++ b/gpu.c
@@ -4742,7 +4742,7 @@ static __isl_give isl_schedule *compute_schedule(struct gpu_gen *gen)
 	isl_schedule_constraints *sc;
 	isl_schedule *schedule;
 
-	sc = construct_schedule_constraints(gen->prog);
+	sc = isl_schedule_constraints_copy(gen->prog->sc);
 	if (gen->add_schedule_constraints)
 		sc = isl_schedule_constraints_set_custom_constraint_callback(sc,
 			gen->add_schedule_constraints,
@@ -4784,10 +4784,9 @@ static __isl_give isl_schedule *determine_properties_original_schedule(
 	isl_schedule_constraints *sc;
 
 	schedule = isl_schedule_copy(gen->prog->scop->schedule);
-	sc = construct_schedule_constraints(gen->prog);
+	sc = gen->prog->sc;
 	schedule = isl_schedule_map_schedule_node_bottom_up(schedule,
 						    &set_band_properties, sc);
-	isl_schedule_constraints_free(sc);
 
 	return schedule;
 }
@@ -6036,6 +6035,7 @@ static __isl_give isl_printer *generate(__isl_take isl_printer *p,
 	if (!prog)
 		return isl_printer_free(p);
 
+	prog->sc = construct_schedule_constraints(prog);
 	gen->prog = prog;
 	schedule = get_schedule(gen);
 
@@ -6240,6 +6240,7 @@ void *gpu_prog_free(struct gpu_prog *prog)
 	isl_union_map_free(prog->tagged_must_kill);
 	isl_union_map_free(prog->array_order);
 	isl_union_set_free(prog->may_persist);
+	isl_schedule_constraints_free(prog->sc);
 	isl_set_free(prog->context);
 	free(prog);
 	return NULL;

--- a/gpu.c
+++ b/gpu.c
@@ -24,6 +24,7 @@
 #include <isl/schedule_node.h>
 #include <isl/options.h>
 #include <isl/ast_build.h>
+#include <isl/point.h>
 
 #include "cpu.h"
 #include "gpu.h"
@@ -4378,6 +4379,88 @@ __isl_give isl_schedule_node* mark_thread(
         return node;
 }
 
+static int can_handle_multiple_thread_node(struct gpu_gen *gen)
+{
+	if (!gen->options->callbacks)
+		return 0;
+	if (!gen->options->callbacks->mark_thread_callback)
+		return 0;
+	if (!gen->generate_kernel)
+		return 0;
+	return 1;
+}
+
+static __isl_give isl_multi_val *update_cross_band_tile_sizes(
+	__isl_take isl_multi_val *sizes, __isl_keep isl_union_map *all_sizes,
+	int id)
+{
+	isl_space *space;
+	isl_set *cross;
+	isl_point *point;
+	isl_bool is_void;
+
+	space = isl_multi_val_get_space(sizes);
+	space = isl_space_from_range(space);
+	space = isl_space_flatten_range(space);
+	space = isl_space_add_dims(space, isl_dim_in, 1);
+	space = isl_space_set_tuple_name(space, isl_dim_in, "kernel");
+	space = isl_space_set_tuple_name(space, isl_dim_out, "cross");
+	cross = isl_map_range(isl_union_map_extract_map(all_sizes, space));
+	point = isl_set_sample_point(cross);
+	is_void = isl_point_is_void(point);
+	if (is_void < 0) {
+		sizes = isl_multi_val_free(sizes);
+	} else if (!is_void) {
+		int i, n;
+
+		n = isl_multi_val_dim(sizes, isl_dim_set);
+		for (i = 0; i < n; ++i) {
+			isl_val *v;
+
+			v = isl_point_get_coordinate_val(point, isl_dim_set, i);
+			sizes = isl_multi_val_set_val(sizes, i, v);
+		}
+	}
+	isl_point_free(point);
+	return sizes;
+}
+
+static __isl_give isl_schedule_node *mark_outer_cross_band(
+	__isl_take isl_schedule_node *node, struct gpu_gen *gen)
+{
+	int i, n;
+	int scale;
+	isl_space *space;
+	isl_val *size;
+	isl_multi_val *sizes;
+
+	space = ppcg_schedule_node_get_cross_tile_space(node);
+	sizes = isl_multi_val_zero(space);
+
+	size = isl_val_int_from_si(gen->ctx, gen->options->tile_size);
+	n = isl_multi_val_dim(sizes, isl_dim_set);
+	for (i = 0; i < n; ++i)
+		sizes = isl_multi_val_set_val(sizes, i, isl_val_copy(size));
+	isl_val_free(size);
+
+	sizes = update_cross_band_tile_sizes(sizes, gen->sizes, gen->kernel_id);
+
+	node = ppcg_schedule_node_cross_tile(node, isl_multi_val_copy(sizes),
+						gen->prog->sc);
+
+	node = isl_schedule_node_child(node, 0);
+	node = mark_thread(node, gen);
+
+	scale = gen->options->scale_tile_loops;
+
+	sizes = isl_multi_val_factor_domain(sizes);
+	node = gen->generate_kernel(gen, node, scale, sizes,
+				    gen->generate_kernel_user);
+	isl_multi_val_free(sizes);
+
+	return node;
+}
+
 /* If "node" is the outermost permutable band that can be mapped to block and
  * thread identifiers in its branch (or the root of a subtree with
  * no such outer bands),
@@ -4423,6 +4506,17 @@ static __isl_give isl_schedule_node *mark_outer_permutable(
 		isl_schedule_node_free(saved);
 		if (node != saved)
 			return node;
+	}
+
+	if (gen->options->cross_band_tile &&
+	    can_handle_multiple_thread_node(gen)) {
+		isl_bool can_cross_tile;
+		can_cross_tile = ppcg_schedule_node_can_cross_tile(node,
+								gen->prog->sc);
+		if (can_cross_tile < 0)
+			return isl_schedule_node_free(node);
+		if (can_cross_tile)
+			return mark_outer_cross_band(node, gen);
 	}
 
 	if (isl_schedule_node_get_type(node) != isl_schedule_node_band ||

--- a/gpu.h
+++ b/gpu.h
@@ -190,6 +190,8 @@ struct gpu_prog {
 	/* All tagged definite kills in the entire program */
 	isl_union_map *tagged_must_kill;
 
+	isl_schedule_constraints *sc;
+
 	/* The set of inner array elements that may be preserved. */
 	isl_union_set *may_persist;
 

--- a/ppcg_options.c
+++ b/ppcg_options.c
@@ -130,6 +130,8 @@ ISL_ARG_BOOL(struct ppcg_options, live_range_reordering, 0,
 ISL_ARG_BOOL(struct ppcg_options, hybrid, 0, "hybrid", 0,
 	"apply hybrid tiling whenever a suitable input pattern is found "
 	"(GPU targets)")
+ISL_ARG_BOOL(struct ppcg_options, cross_band_tile, 0, "tile_cross_band", 0,
+	"apply cross band tiling (GPU targets)")
 ISL_ARG_BOOL(struct ppcg_options, unroll_copy_shared, 0, "unroll-copy-shared",
 	0, "unroll code for copying to/from shared memory")
 ISL_ARG_BOOL(struct ppcg_options, unroll_gpu_tile, 0, "unroll-gpu-tile", 0,

--- a/ppcg_options.h
+++ b/ppcg_options.h
@@ -73,6 +73,9 @@ struct ppcg_options {
 	/* Allow hybrid tiling whenever a suitable input pattern is found. */
 	int hybrid;
 
+	/* Apply cross band tiling whenever suitable input pattern is found. */
+	int cross_band_tile;
+
 	/* Unroll the code for copying to/from shared memory. */
 	int unroll_copy_shared;
 	/* Unroll code inside tile on GPU targets. */


### PR DESCRIPTION
```
skimo@outside:~/git/c2isl$ build/test/test_tc_batchmatmul 
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from IslBatchMatMul
[ RUN      ] IslBatchMatMul.BatchMatMul
can cross tile: 0
isl_ctx freed, but some objects still reference it
[       OK ] IslBatchMatMul.BatchMatMul (1955 ms)
[----------] 1 test from IslBatchMatMul (1955 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (1955 ms total)
[  PASSED  ] 1 test.
skimo@outside:~/git/c2isl$ build/test/test_2fcrelu
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from Isl2FCRelu
[ RUN      ] Isl2FCRelu.Default
can cross tile: 1
isl_ctx freed, but some objects still reference it
[       OK ] Isl2FCRelu.Default (2393 ms)
[----------] 1 test from Isl2FCRelu (2393 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (2393 ms total)
[  PASSED  ] 1 test.
```