### PR TITLE
brutally replace AST unroll options with #pragma unroll for CUDA

### DIFF
--- a/cuda.c
+++ b/cuda.c
@@ -522,6 +522,23 @@ static __isl_give isl_printer *print_kernel_stmt(__isl_take isl_printer *p,
 	return p;
 }
 
+static __isl_give isl_printer *print_for_with_pragma(__isl_take isl_printer *p,
+	__isl_take isl_ast_print_options *print_options,
+	__isl_keep isl_ast_node *node, void *usr) 
+{
+	isl_id *id;
+	(void) usr;
+
+	id = isl_ast_node_get_annotation(node);
+	if (id && !strcmp(isl_id_get_name(id), "pragma-unroll-for")) {
+		p = isl_printer_start_line(p);
+		p = isl_printer_print_str(p, "#pragma unroll");
+		p = isl_printer_end_line(p);
+	}
+	isl_id_free(id);
+	return isl_ast_node_for_print(node, p, print_options);
+}
+
 static void print_kernel(struct gpu_prog *prog, struct ppcg_kernel *kernel,
 	struct cuda_info *cuda)
 {
@@ -545,6 +562,8 @@ static void print_kernel(struct gpu_prog *prog, struct ppcg_kernel *kernel,
 	print_options = isl_ast_print_options_alloc(ctx);
 	print_options = isl_ast_print_options_set_print_user(print_options,
 						    &print_kernel_stmt, NULL);
+	print_options = isl_ast_print_options_set_print_for(
+			print_options, &print_for_with_pragma, NULL);
 	p = isl_ast_node_print(kernel->tree, p, print_options);
 	isl_printer_free(p);
 

--- a/schedule.h
+++ b/schedule.h
@@ -40,4 +40,12 @@ __isl_give isl_schedule_node *ppcg_schedule_node_cross_tile(
 	__isl_take isl_schedule_node *node, __isl_take isl_multi_val *sizes,
 	__isl_keep isl_schedule_constraints *sc);
 
+struct pragma_unroll_annotation {
+  int n;
+  int *dims;
+};
+
+struct pragma_unroll_annotation *alloc_pragma_unroll_annotation(isl_ctx *ctx, int n);
+void free_pragma_unroll_annotation(void *v);
+
 #endif


### PR DESCRIPTION
Replaces AST loop unroll option with mark nodes in schedule trees that are read
during AST generation and transformed into CUDA #pragma unroll directives.

This must be made a ppcg_option that is only operational for CUDA backend.