### PR TITLE
Fix header installation to properly install headers only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,7 +133,8 @@ install (TARGETS ppcg-static
 
 install (TARGETS ppcg_bin DESTINATION bin)
 
-install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR} DESTINATION include FILES_MATCHING PATTERN "*.h")
+file(GLOB header_files *.h)
+install(FILES ${header_files} DESTINATION include/ppcg)
 
 ################################################################################
 # Add tests


### PR DESCRIPTION
There were two problems with the way headers were installed before:

It looks at all the .h files and recursively copies then to the destination third-party-install/ppcg/ however it also copies the sub directories like examples, build etc to third-party-install/ppcg/ although those are empty created there.